### PR TITLE
fix(messagelistener.ts): generate events for custom domain

### DIFF
--- a/src/eventSystem/messageListener/messageListener.spec.ts
+++ b/src/eventSystem/messageListener/messageListener.spec.ts
@@ -1,4 +1,4 @@
-import { FullscriptOptions } from "src/fullscript";
+import { FullscriptOptions } from "../../fullscript";
 import { createDispatcher, Dispatcher } from "../dispatcher";
 
 import { initializeMessageListener } from "./messageListener";
@@ -48,8 +48,8 @@ describe("initializeMessageListener", () => {
     let mockCallback;
     const optionsWithDomain = {
       ...mockFullscriptOptions,
-      domain: "http://test.fullscript.com"
-    }
+      domain: "http://test.fullscript.com",
+    };
     const addEventListener = jest.fn((_, callback) => {
       mockCallback = callback;
     });

--- a/src/eventSystem/messageListener/messageListener.ts
+++ b/src/eventSystem/messageListener/messageListener.ts
@@ -1,8 +1,9 @@
-import { FullscriptEnv, FULLSCRIPT_DOMAINS } from "../../fullscript";
+import { FullscriptOptions, FULLSCRIPT_DOMAINS } from "../../fullscript";
 import { Dispatcher } from "../dispatcher";
 
-const initializeMessageListener = (env: FullscriptEnv, dispatcher: Dispatcher): void => {
-  const origin = FULLSCRIPT_DOMAINS[env];
+const initializeMessageListener = (options: FullscriptOptions, dispatcher: Dispatcher): void => {
+  const { domain, env } = options;
+  const origin = domain ?? FULLSCRIPT_DOMAINS[env];
 
   window.addEventListener("message", (e: MessageEvent) => {
     // !!!! Absolutely required for security purposes !!!!!

--- a/src/feature/featureUtil.ts
+++ b/src/feature/featureUtil.ts
@@ -14,7 +14,7 @@ const getFeatureURL = <F extends FeatureType>(
   const { publicKey, env, domain } = fullscriptOptions;
   const queryString = buildQueryString({ ...featureOptions, publicKey, frameId });
   validateFeatureType(featureType);
-  const fsDomain = domain ? domain : FULLSCRIPT_DOMAINS[env];
+  const fsDomain = domain?? FULLSCRIPT_DOMAINS[env];
 
   return `${fsDomain}/api/embeddable/session${FEATURE_PATHS[featureType]}${queryString}&target_origin=${window.location.origin}`;
 };

--- a/src/feature/featureUtil.ts
+++ b/src/feature/featureUtil.ts
@@ -14,7 +14,7 @@ const getFeatureURL = <F extends FeatureType>(
   const { publicKey, env, domain } = fullscriptOptions;
   const queryString = buildQueryString({ ...featureOptions, publicKey, frameId });
   validateFeatureType(featureType);
-  const fsDomain = domain?? FULLSCRIPT_DOMAINS[env];
+  const fsDomain = domain ?? FULLSCRIPT_DOMAINS[env];
 
   return `${fsDomain}/api/embeddable/session${FEATURE_PATHS[featureType]}${queryString}&target_origin=${window.location.origin}`;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,6 @@ export type {
 export const Fullscript = (options: FullscriptOptions): Client => {
   validateFullscriptOptions(options);
   const eventDispatcher = createDispatcher();
-  initializeMessageListener(options.env, eventDispatcher);
+  initializeMessageListener(options, eventDispatcher);
   return createClient(options, eventDispatcher);
 };


### PR DESCRIPTION
Generate events when fullscript client is initialized with a custom domain