### PR TITLE
Prevent rendering duplicate iFrame wrappers

### DIFF
--- a/src/feature/feature.ts
+++ b/src/feature/feature.ts
@@ -7,7 +7,7 @@ import { createIframe } from "../iframe";
 import { removeChildren } from "../utils";
 
 import { EventType, EventListenerCallback } from "./eventType";
-import { FeatureType, FeatureOptions, Feature } from "./featureType";
+import { FeatureType, FeatureOptions, Feature, WRAPPER_DIV_ID } from "./featureType";
 import { getFeatureURL } from "./featureUtil";
 
 const getFeature = <F extends FeatureType>(
@@ -24,8 +24,11 @@ const getFeature = <F extends FeatureType>(
     const url = await getFeatureURL(featureType, featureOptions, fullscriptOptions, frameId);
     mountPoint = document.getElementById(elementId);
     validateMountPoint(mountPoint);
-    const iframe = createIframe(url);
-    mountPoint.appendChild(iframe);
+
+    if (!mountPoint.querySelector(`#${WRAPPER_DIV_ID}`)) {
+      const iframe = createIframe(url);
+      mountPoint.appendChild(iframe);
+    }
   };
 
   const unmount = () => {

--- a/src/feature/featureType.ts
+++ b/src/feature/featureType.ts
@@ -4,6 +4,8 @@ const FEATURE_TYPES = {
   treatmentPlan: "treatmentPlan",
 };
 
+const WRAPPER_DIV_ID = "wrapper-div";
+
 type FeatureType = keyof typeof FEATURE_TYPES;
 
 type PatientOptions = {
@@ -37,4 +39,5 @@ export {
   PatientOptions,
   Feature,
   FEATURE_TYPES,
+  WRAPPER_DIV_ID,
 };

--- a/src/iframe/loader/containers/containers.ts
+++ b/src/iframe/loader/containers/containers.ts
@@ -1,3 +1,5 @@
+import { WRAPPER_DIV_ID } from "../../../feature/featureType";
+
 import * as styles from "./styles";
 
 type DivAttributes = {
@@ -22,7 +24,7 @@ const createDiv = (attributes: DivAttributes): HTMLDivElement => {
 };
 
 const createWrapper = (): HTMLDivElement => {
-  return createDiv({ style: styles.wrapper });
+  return createDiv({ id: WRAPPER_DIV_ID, style: styles.wrapper });
 };
 
 const createLoader = (): HTMLDivElement => {


### PR DESCRIPTION
fix(feature.ts, containers.ts): adds a check to prevent mounting a new iframe if one exists

Depending on the users implementation, if they call the mount function more than once (possibly from a useEffect), another wrapper div is rendered under the first one. this fix adds a check to prevent mounting if one exists already.

See previous behaviour (can be reproduced by duplicating the `mountTreatmentPlan();` command in `demo/react-demo/src/App.tsx`.

```tsx
const App = () => {
  useEffect(() => {
    mountTreatmentPlan();
    mountTreatmentPlan();  // to mimic the `useEffect` code running again after the first render
  }, []);
 ...
}
```

[Gitlab ticket from EHR partner](https://git.fullscript.io/developers/hw-admin/-/issues/31001)

https://user-images.githubusercontent.com/22198877/226686324-460a78f3-999f-45d6-8509-478022c8c4f8.mov



