### PR TITLE
fix(package.json): upgrade core-js package to 3.32

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -7,7 +7,7 @@ module.exports = function (api) {
           "@babel/preset-env",
           {
             useBuiltIns: "usage",
-            corejs: "3",
+            corejs: "3.32",
             targets: ["last 2 versions", "not dead", "not < 2%", "ie >= 11"], //https://browserl.ist/?q=last+2+versions%2C+not+dead%2C+%3E+0.2%25%2C+ie+%3E%3D11
           },
         ],

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "core-js": "3",
+    "core-js": "3.32.0",
     "regenerator-runtime": "^0.13.5",
     "uuid": "^8.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3023,10 +3023,10 @@ core-js-compat@^3.6.2:
     browserslist "^4.8.5"
     semver "7.0.0"
 
-core-js@3:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
-  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
+core-js@3.32.0:
+  version "3.32.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.32.0.tgz#7643d353d899747ab1f8b03d2803b0312a0fb3b6"
+  integrity sha512-rd4rYZNlF3WuoYuRIDEmbR/ga9CeuWX9U05umAvgrrZoHY4Z++cp/xwPQMvUpBB4Ag6J8KfD80G0zwCyaSxDww==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
This PR upgrades the `core-js` version to `3.32`. We found that when there is an existing `core-js` dependency with a higher version, there's a conflict. 

This means regular upgrades will be needed to stay proactive 