### PR TITLE
fix(package.json, babel.config.js and yarn.lock): update our list of …

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,7 +8,6 @@ module.exports = function (api) {
           {
             useBuiltIns: "usage",
             corejs: "3.32",
-            targets: ["last 2 versions", "not dead", "not < 2%", "ie >= 11"], //https://browserl.ist/?q=last+2+versions%2C+not+dead%2C+%3E+0.2%25%2C+ie+%3E%3D11
           },
         ],
         ["@babel/preset-typescript"],

--- a/package.json
+++ b/package.json
@@ -73,6 +73,21 @@
     "regenerator-runtime": "^0.13.5",
     "uuid": "^8.3.0"
   },
+  "browserslist": [
+    "defaults",
+    "last 1 version",
+    "> 0.2%",
+    "not dead",
+    "not IE > 0",
+    "ios_saf >= 10.3",
+    "safari >= 10.1",
+    "not op_mini all",
+    "not baidu <= 100",
+    "not kaiOS <= 100",
+    "not android <= 5.0",
+    "not and_uc <= 100",
+    "not and_qq <= 100"
+  ],
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2487,9 +2487,9 @@ camelcase@^6.0.0:
   integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
 
 caniuse-lite@^1.0.30001093:
-  version "1.0.30001104"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001104.tgz#4e3d5b3b1dd3c3529f10cb7f519c62ba3e579f5d"
-  integrity sha512-pkpCg7dmI/a7WcqM2yfdOiT4Xx5tzyoHAXWsX5/HxZ3TemwDZs0QXdqbE0UPLPVy/7BeK7693YfzfRYfu1YVpg==
+  version "1.0.30001518"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz"
+  integrity sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
…supported browsers

Update our list of supported browsers so that babel doesn't include so many core-js modules and the total size of the script is smaller.