### PR TITLE
feat(app): render platform experience (FS Embed) in iframe

### DIFF
--- a/src/feature/featurePath.ts
+++ b/src/feature/featurePath.ts
@@ -1,7 +1,8 @@
-type FeaturePaths = "/treatment_plans/new";
+type FeaturePaths = "/treatment_plans/new" | "/embed/entry";
 
 const FEATURE_PATHS: { [key: string]: FeaturePaths } = {
   treatmentPlan: "/treatment_plans/new",
+  platform: "/embed/entry",
 };
 
 export { FeaturePaths, FEATURE_PATHS };

--- a/src/feature/featureType.ts
+++ b/src/feature/featureType.ts
@@ -2,6 +2,7 @@ import { EventListenerFunction } from "./eventType";
 
 const FEATURE_TYPES = {
   treatmentPlan: "treatmentPlan",
+  platform: "platform",
 };
 
 type FeatureType = keyof typeof FEATURE_TYPES;
@@ -19,7 +20,7 @@ type PatientOptions = {
 };
 type TreatmentPlanOptions = { patient?: PatientOptions; secretToken: string };
 
-type FeatureOptions<F extends FeatureType> = F extends "treatmentPlan"
+type FeatureOptions<F extends FeatureType> = F extends "treatmentPlan" | "platform"
   ? TreatmentPlanOptions
   : Record<any, never>;
 

--- a/src/feature/featureUtil.spec.ts
+++ b/src/feature/featureUtil.spec.ts
@@ -4,7 +4,7 @@ import { FeatureOptions } from "./featureType";
 import { getFeatureURL } from "./featureUtil";
 
 describe("getFeatureUrl", () => {
-  let mockFeatureOptions: FeatureOptions<"treatmentPlan">;
+  let mockFeatureOptions: FeatureOptions<"treatmentPlan" | "platform">;
   let mockFullscriptOptions: FullscriptOptions;
   let mockFrameId: string;
   const mockDataToken = "random+data_token";
@@ -31,39 +31,58 @@ describe("getFeatureUrl", () => {
     mockFrameId = "uuid";
   });
 
-  it("returns the proper url", async () => {
-    const url = await getFeatureURL(
-      "treatmentPlan",
-      mockFeatureOptions,
-      mockFullscriptOptions,
-      mockFrameId
-    );
+  describe("feature type", () => {
+    it("returns the proper url when the feature type is 'treatmentPlan'", async () => {
+      const url = await getFeatureURL(
+        "treatmentPlan",
+        mockFeatureOptions,
+        mockFullscriptOptions,
+        mockFrameId
+      );
 
-    expect(url).toEqual(
-      `https://us-snd.fullscript.io/api/embeddable/session/treatment_plans/new?data_token=${encodeURIComponent(
-        mockDataToken
-      )}&secret_token=secretToken&public_key=publicKey&frame_id=uuid&target_origin=http://localhost`
-    );
+      expect(url).toEqual(
+        `https://us-snd.fullscript.io/api/embeddable/session/treatment_plans/new?data_token=${encodeURIComponent(
+          mockDataToken
+        )}&secret_token=secretToken&public_key=publicKey&frame_id=uuid&target_origin=http://localhost`
+      );
+    });
+
+    it("returns the proper url when the feature type is 'platform'", async () => {
+      const url = await getFeatureURL(
+        "platform",
+        mockFeatureOptions,
+        mockFullscriptOptions,
+        mockFrameId
+      );
+
+      expect(url).toEqual(
+        `https://us-snd.fullscript.io/api/embeddable/session/embed/entry?data_token=${encodeURIComponent(
+          mockDataToken
+        )}&secret_token=secretToken&public_key=publicKey&frame_id=uuid&target_origin=http://localhost`
+      );
+    });
   });
 
-  it("returns proper custom url if domain is present", async () => {
-    const customDomain = "https://staging.r.fullscript.io";
-    mockFullscriptOptions = {
-      ...mockFullscriptOptions,
-      domain: customDomain,
-    };
+  describe("custome domain", () => {
+    it("returns proper custom url if domain is present", async () => {
+      const customDomain = "https://staging.r.fullscript.io";
+      mockFullscriptOptions = {
+        ...mockFullscriptOptions,
+        domain: customDomain,
+      };
 
-    const url = await getFeatureURL(
-      "treatmentPlan",
-      mockFeatureOptions,
-      mockFullscriptOptions,
-      mockFrameId
-    );
+      const url = await getFeatureURL(
+        "treatmentPlan",
+        mockFeatureOptions,
+        mockFullscriptOptions,
+        mockFrameId
+      );
 
-    expect(url).toEqual(
-      `${customDomain}/api/embeddable/session/treatment_plans/new?data_token=${encodeURIComponent(
-        mockDataToken
-      )}&secret_token=secretToken&public_key=publicKey&frame_id=uuid&target_origin=http://localhost`
-    );
+      expect(url).toEqual(
+        `${customDomain}/api/embeddable/session/treatment_plans/new?data_token=${encodeURIComponent(
+          mockDataToken
+        )}&secret_token=secretToken&public_key=publicKey&frame_id=uuid&target_origin=http://localhost`
+      );
+    });
   });
 });


### PR DESCRIPTION
This change enables users to use platform experience (FS Embed). This new experience is optional to use at this moment and it doesn't break the existing one.