### PR TITLE
chore(husky): added prepare hook for husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "test": "yarn install && jest --maxWorkers=2",
     "demo:npm": "yarn --cwd ./demo/react-demo start",
     "demo:umd": "yarn --cwd ./demo/javascript-demo/server dev",
-    "watch": "concurrently \"yarn:watch:*\""
+    "watch": "concurrently \"yarn:watch:*\"",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@babel/cli": "^7.27.2",


### PR DESCRIPTION
## Description

Noticed that the prepare hook for husky is missing. `commitizen` doesn't work when we commit a new change without this hook

## Test

1. Pull this branch in your local
2. Run `yarn install`
3. Make sure a new directory is created under `.husky` directory
4. Change a file and commit it
5. Make sure `commitizen` is booted