### PR TITLE
update treatment plan payload event to include lab recommendations

### DIFF
--- a/src/feature/eventType.ts
+++ b/src/feature/eventType.ts
@@ -43,6 +43,16 @@ type TreatmentPlanPayload = {
         additionalInfo: string;
       };
     }[];
+    lab_recommendations: {
+      id: string;
+      name: string;
+      requiresFasting: boolean;
+      instructions: string;
+      tests:{
+        id:string;
+        name:string;
+      }[];
+    }[];
   };
 };
 


### PR DESCRIPTION
Updates type for event emitted when treatment plan is sent to patient. types added for lab_recommendations. should sync up with event emitted from fullscript embed tester