### PR TITLE
feat(events): add patient details to treatment plan event output

### DIFF
--- a/src/feature/eventType.ts
+++ b/src/feature/eventType.ts
@@ -27,6 +27,9 @@ type TreatmentPlanPayload = {
     state: string;
     patient: {
       id: string;
+      firstNane: string;
+      lastName: string;
+      email: string;
     };
     practitioner: {
       id: string;


### PR DESCRIPTION
Updates type to match new output of `treatmentPlan.activated` event. Adds first and last name and email as identifying features.