### PR TITLE
chore(package.json): replaced "prepare" hook with "postintall"

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "demo:npm": "yarn --cwd ./demo/react-demo start",
     "demo:umd": "yarn --cwd ./demo/javascript-demo/server dev",
     "watch": "concurrently \"yarn:watch:*\"",
-    "prepare": "husky"
+    "postinstall": "husky"
   },
   "devDependencies": {
     "@babel/cli": "^7.27.2",


### PR DESCRIPTION
 I added `prepare` hook in [this PR](https://github.com/Fullscript/fullscript-js/pull/37) to run `husky` command when installing dependencies, but I noticed the hook also works when publishing a new version of the library which is not what I expected. 

This PR replaces "prepare" hook with "postintall" to prevent it from running when publishing a new version.